### PR TITLE
Build ComfyUI image locally

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,3 +37,4 @@ OLLAMA_GPU=false
 
 # ====== ComfyUI ======
 COMFYUI_DOMAIN=comfyui.halai.local
+COMFYUI_GIT_REF=master

--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ Traefik genererà automaticamente certificati Let's Encrypt per i domini pubblic
 - Aggiornare i servizi eseguendo `docker compose pull` seguito da `docker compose up -d`.
 - Monitorare i log con `docker compose logs -f <nome-servizio>`.
 - In caso di errori Traefik sui certificati, eliminare `traefik_letsencrypt/acme.json` (verrà rigenerato) e riavviare.
+- Il container di ComfyUI viene costruito localmente a partire dal repository ufficiale (vedi `docker/comfyui/`). È possibile
+  selezionare un branch o tag specifico impostando la variabile `COMFYUI_GIT_REF` nel file `.env`.
 
 ---
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -162,7 +162,11 @@ services:
       - "traefik.http.services.openwebui.loadbalancer.server.port=8080"
 
   comfyui:
-    image: ghcr.io/comfyanonymous/comfyui:latest
+    build:
+      context: ./docker/comfyui
+      args:
+        COMFYUI_GIT_REF: ${COMFYUI_GIT_REF:-master}
+    image: halai-comfyui:latest
     restart: unless-stopped
     environment:
       - CLI_ARGS=--listen 0.0.0.0 --port 8188

--- a/docker/comfyui/Dockerfile
+++ b/docker/comfyui/Dockerfile
@@ -1,0 +1,37 @@
+# syntax=docker/dockerfile:1
+
+FROM python:3.11-slim AS base
+
+ENV PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    COMFYUI_HOME=/opt/ComfyUI
+
+ARG COMFYUI_GIT_REPO=https://github.com/comfyanonymous/ComfyUI.git
+ARG COMFYUI_GIT_REF=master
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        git \
+        ffmpeg \
+        libgl1 \
+        libglib2.0-0 \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR ${COMFYUI_HOME}
+
+RUN git clone --branch "${COMFYUI_GIT_REF}" --depth 1 "${COMFYUI_GIT_REPO}" "${COMFYUI_HOME}"
+
+WORKDIR ${COMFYUI_HOME}
+
+RUN pip install --upgrade pip setuptools wheel \
+    && pip install -r requirements.txt
+
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+EXPOSE 8188
+
+ENV CLI_ARGS=""
+
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+CMD []

--- a/docker/comfyui/docker-entrypoint.sh
+++ b/docker/comfyui/docker-entrypoint.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "${COMFYUI_HOME:-/opt/ComfyUI}"
+
+if [ -n "${CLI_ARGS:-}" ]; then
+  set -- python main.py ${CLI_ARGS}
+else
+  set -- python main.py
+fi
+
+exec "$@"


### PR DESCRIPTION
## Summary
- add a local Docker build context for ComfyUI to remove the dependency on the private GHCR image
- expose a configurable COMFYUI_GIT_REF variable and document the new build process
- update docker-compose to build the image from the bundled Dockerfile

## Testing
- not run (docker command unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68d3c140ae4c83209dfe647d7463e4da