### PR TITLE
Fix postgres healthcheck configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,10 +40,13 @@ services:
     volumes:
       - ./postgres_data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER}"]
+      test:
+        - CMD-SHELL
+        - pg_isready -d "$${POSTGRES_DB:-$${POSTGRES_USER:-postgres}}" -U "$${POSTGRES_USER:-postgres}"
       interval: 10s
       timeout: 5s
       retries: 5
+      start_period: 30s
 
   redis:
     image: redis:7-alpine


### PR DESCRIPTION
## Summary
- ensure the Postgres healthcheck targets the configured database and user
- give the container a small start period to finish initialization before health probes run

## Testing
- not run (not available in container environment)


------
https://chatgpt.com/codex/tasks/task_e_68d3d0dcbab4832082638163ba379599